### PR TITLE
Feature/no rinterface header

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-05-15  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/RInsideCommon.h: Do not include RInterface.h
+	* src/RInside.cpp: Do not set R_SignalHandlers and R_CStackLimit
+
 2015-01-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION: Release 0.2.12

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,9 @@
 2015-05-15  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/RInsideCommon.h: Do not include RInterface.h
-	* src/RInside.cpp: Do not set R_SignalHandlers and R_CStackLimit
+	* inst/include/RInsideCommon.h: Do not include RInterface.h here as
+	the file gets included from several source files
+
+	* src/RInside.cpp: But rather include RInterface.h here just once
 
 2015-01-27  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/RInsideCommon.h
+++ b/inst/include/RInsideCommon.h
@@ -51,10 +51,10 @@
 #endif
 
 #include <Rembedded.h>
-#ifndef WIN32
-  #define R_INTERFACE_PTRS
-  #include <Rinterface.h>
-#endif
+// #ifndef WIN32
+//   #define R_INTERFACE_PTRS
+//   #include <Rinterface.h>
+// #endif
 #include <R_ext/RStartup.h>
 
 #include <MemBuf.h>

--- a/inst/include/RInsideCommon.h
+++ b/inst/include/RInsideCommon.h
@@ -51,10 +51,6 @@
 #endif
 
 #include <Rembedded.h>
-// #ifndef WIN32
-//   #define R_INTERFACE_PTRS
-//   #include <Rinterface.h>
-// #endif
 #include <R_ext/RStartup.h>
 
 #include <MemBuf.h>

--- a/src/RInside.cpp
+++ b/src/RInside.cpp
@@ -135,9 +135,9 @@ void RInside::initialize(const int argc, const char* const argv[], const bool lo
         }
     }
 
-    #ifndef WIN32
-    R_SignalHandlers = 0;               // Don't let R set up its own signal handlers
-    #endif
+    // #ifndef WIN32
+    // R_SignalHandlers = 0;               // Don't let R set up its own signal handlers
+    // #endif
 
     init_tempdir();
 
@@ -146,9 +146,9 @@ void RInside::initialize(const int argc, const char* const argv[], const bool lo
     int R_argc = sizeof(R_argv) / sizeof(R_argv[0]);
     Rf_initEmbeddedR(R_argc, (char**)R_argv);
 
-    #ifndef WIN32
-    R_CStackLimit = -1;      		// Don't do any stack checking, see R Exts, '8.1.5 Threading issues'
-    #endif
+    // #ifndef WIN32
+    // R_CStackLimit = -1;      		// Don't do any stack checking, see R Exts, '8.1.5 Threading issues'
+    // #endif
 
     R_ReplDLLinit();                    // this is to populate the repl console buffers
 

--- a/src/RInside.cpp
+++ b/src/RInside.cpp
@@ -22,6 +22,10 @@
 
 #include <RInside.h>
 #include <Callbacks.h>
+#ifndef WIN32
+  #define R_INTERFACE_PTRS
+  #include <Rinterface.h>
+#endif
 
 RInside* RInside::instance_m = 0 ;
 

--- a/src/RInside.cpp
+++ b/src/RInside.cpp
@@ -139,9 +139,9 @@ void RInside::initialize(const int argc, const char* const argv[], const bool lo
         }
     }
 
-    // #ifndef WIN32
-    // R_SignalHandlers = 0;               // Don't let R set up its own signal handlers
-    // #endif
+    #ifndef WIN32
+    R_SignalHandlers = 0;               // Don't let R set up its own signal handlers
+    #endif
 
     init_tempdir();
 
@@ -150,9 +150,9 @@ void RInside::initialize(const int argc, const char* const argv[], const bool lo
     int R_argc = sizeof(R_argv) / sizeof(R_argv[0]);
     Rf_initEmbeddedR(R_argc, (char**)R_argv);
 
-    // #ifndef WIN32
-    // R_CStackLimit = -1;      		// Don't do any stack checking, see R Exts, '8.1.5 Threading issues'
-    // #endif
+    #ifndef WIN32
+    R_CStackLimit = -1;      		// Don't do any stack checking, see R Exts, '8.1.5 Threading issues'
+    #endif
 
     R_ReplDLLinit();                    // this is to populate the repl console buffers
 


### PR DESCRIPTION
This helps with the buglet in R 3.2.0 discussed [in this R bugreport](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=15899) by only including `RInterface.h` once so that we do not get multiple instances.