### PR TITLE
Fix for empty envvars on windows

### DIFF
--- a/src/tools/RInsideEnvVars.r
+++ b/src/tools/RInsideEnvVars.r
@@ -7,6 +7,7 @@ IncludeVars <- Sys.getenv()
 IncludeVars <- IncludeVars[grep("^R_",names(IncludeVars),perl=TRUE)]
 if (.Platform$OS.type == "windows") {
     IncludeVars <- gsub("\\\\", "/", IncludeVars, perl=TRUE)
+    IncludeVars <- gsub("\r", "", IncludeVars, fixed = TRUE)
 }
 cat("    const char *R_VARS[] = {\n")
 for (i in 1:length(IncludeVars)){


### PR DESCRIPTION
For whatever reason, windows sometimes turns an empty environment variable into `\r` which gcc then interprets as a linebreak.