### PR TITLE
Fix to windows setenv() which would strip single backslashes

### DIFF
--- a/src/setenv/setenv.c
+++ b/src/setenv/setenv.c
@@ -60,8 +60,16 @@ extern "C" int setenv(const char *env_var, const char *env_val, int dummy) {
 	}
 
 	if(!inquote && *p == '\\') {
-	    if(*(p+1) == '\n') p++;
-	    else if(*(p+1) == '\\') *q++ = *p;
+	    if(*(p+1) == '\n') {
+	        p++;
+	    }
+	    else if(*(p+1) == '\\') {
+	        *q++ = '/';
+	        p++;
+	    }
+	    else {
+	        *q++ = '/';
+	    }
 	    continue;
 	}
 


### PR DESCRIPTION
hi dirk,

i found that `setenv()` from `setenv.c` would perform the following modifications to the variable:

`C:\Users\\Jonathon\\\Documents\\\\Fred` -> `C:Users\Jonathon\\Documents\\\Fred`

where as i believe a better behaviour would be:

`C:\Users\\Jonathon\\\Documents\\\\Fred` -> `C:\Users\Jonathon\\Documents\\Fred`

(the original behaviour resulted in an `R_SESSION_TMPDIR` on my machine of `C:UsersJonathonAppDataLocalTemp`)

there was a mixture of tabs and spaces in `setenv.c`, so i corrected that in the first commit, where as the second commit contains my proposed changes.

with thanks