### PR TITLE
quoted Rscript path

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -25,7 +25,7 @@ USERDIR =	../inst/lib$(R_ARCH)
 PKG_CPPFLAGS =  -I. -I../inst/include/
 PKG_LIBS = 	$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "Rcpp:::LdFlags()")
 
-RSCRIPT =	${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe
+RSCRIPT =	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe"
 
 all:		headers $(SHLIB) userLibrary
 


### PR DESCRIPTION
Without the quotes it couldn't launch the Rscript.exe if there is space in the path.